### PR TITLE
Remove whitespace around RULES directive

### DIFF
--- a/src/Data/Functor/Representable.hs
+++ b/src/Data/Functor/Representable.hs
@@ -83,8 +83,7 @@ class (Distributive f, Indexable f) => Representable f where
   tabulate :: (Key f -> a) -> f a
 
 {-# RULES
-"tabulate/index" forall t. tabulate (index t) = t
- #-}
+"tabulate/index" forall t. tabulate (index t) = t #-}
 
 -- * Default definitions
 


### PR DESCRIPTION
Ending the directive on a separate line was causing GHC 7.6.3 on my system to throw an error:

```
src/Data/Functor/Representable.hs:87:3:
     error: invalid preprocessing directive
     #-}
      ^
1 error generated.
```
